### PR TITLE
Multiple Content Paths

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ subprojects {
 
     ext {
         junit = "4.11"
-        swagger2markup = "1.2.0"
+        swagger2markup = "1.3.0-SNAPSHOT"
     }
 
     tasks.withType(JavaCompile) {

--- a/swagger2markup-extension-commons/src/main/java/io/github/swagger2markup/extensions/DynamicContentExtension.java
+++ b/swagger2markup-extension-commons/src/main/java/io/github/swagger2markup/extensions/DynamicContentExtension.java
@@ -62,21 +62,21 @@ public class DynamicContentExtension extends ContentExtension {
         };
 
         for (Path currentPath : contentPaths) {
-	        try (DirectoryStream<Path> extensionFiles = Files.newDirectoryStream(currentPath, filter)) {
-	
-	            if (extensionFiles != null) {
-	                List<Path> extensions = Lists.newArrayList(extensionFiles);
-	                Collections.sort(extensions, Ordering.natural());
-	
-	                for (Path extension : extensions) {
-	                    importContent(extension,
-	                            (reader) -> contentContext.getMarkupDocBuilder().importMarkup(reader, extensionMarkupLanguage, levelOffset));
-	                }
-	            }
-	        } catch (IOException e) {
-	            if (logger.isDebugEnabled())
-	                logger.debug("Failed to read extension files from directory {}", currentPath);
-	        }
+            try (DirectoryStream<Path> extensionFiles = Files.newDirectoryStream(currentPath, filter)) {
+
+                if (extensionFiles != null) {
+                    List<Path> extensions = Lists.newArrayList(extensionFiles);
+                    Collections.sort(extensions, Ordering.natural());
+
+                    for (Path extension : extensions) {
+                        importContent(extension,
+                                (reader) -> contentContext.getMarkupDocBuilder().importMarkup(reader, extensionMarkupLanguage, levelOffset));
+                    }
+                }
+            } catch (IOException e) {
+                if (logger.isDebugEnabled())
+                    logger.debug("Failed to read extension files from directory {}", currentPath);
+            }
         }
     }
 

--- a/swagger2markup-extension-commons/src/main/java/io/github/swagger2markup/extensions/DynamicContentExtension.java
+++ b/swagger2markup-extension-commons/src/main/java/io/github/swagger2markup/extensions/DynamicContentExtension.java
@@ -47,11 +47,11 @@ public class DynamicContentExtension extends ContentExtension {
      * Builds extension sections
      *
      * @param extensionMarkupLanguage the MarkupLanguage of the snippets content
-     * @param contentPath the path where the content files reside
+     * @param contentPaths the path(s) where the content files reside
      * @param prefix      extension file prefix
      * @param levelOffset import markup level offset
      */
-    public void extensionsSection(MarkupLanguage extensionMarkupLanguage, Path contentPath, final String prefix, int levelOffset) {
+    public void extensionsSection(MarkupLanguage extensionMarkupLanguage, List<Path> contentPaths, final String prefix, int levelOffset) {
         final Collection<String> filenameExtensions = globalContext.getConfig().getMarkupLanguage().getFileNameExtensions().stream()
                 .map(fileExtension -> StringUtils.stripStart(fileExtension, "."))
                 .collect(Collectors.toList());
@@ -61,20 +61,22 @@ public class DynamicContentExtension extends ContentExtension {
             return fileName.startsWith(prefix) && FilenameUtils.isExtension(fileName, filenameExtensions);
         };
 
-        try (DirectoryStream<Path> extensionFiles = Files.newDirectoryStream(contentPath, filter)) {
-
-            if (extensionFiles != null) {
-                List<Path> extensions = Lists.newArrayList(extensionFiles);
-                Collections.sort(extensions, Ordering.natural());
-
-                for (Path extension : extensions) {
-                    importContent(extension,
-                            (reader) -> contentContext.getMarkupDocBuilder().importMarkup(reader, extensionMarkupLanguage, levelOffset));
-                }
-            }
-        } catch (IOException e) {
-            if (logger.isDebugEnabled())
-                logger.debug("Failed to read extension files from directory {}", contentPath);
+        for (Path currentPath : contentPaths) {
+	        try (DirectoryStream<Path> extensionFiles = Files.newDirectoryStream(currentPath, filter)) {
+	
+	            if (extensionFiles != null) {
+	                List<Path> extensions = Lists.newArrayList(extensionFiles);
+	                Collections.sort(extensions, Ordering.natural());
+	
+	                for (Path extension : extensions) {
+	                    importContent(extension,
+	                            (reader) -> contentContext.getMarkupDocBuilder().importMarkup(reader, extensionMarkupLanguage, levelOffset));
+	                }
+	            }
+	        } catch (IOException e) {
+	            if (logger.isDebugEnabled())
+	                logger.debug("Failed to read extension files from directory {}", currentPath);
+	        }
         }
     }
 

--- a/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicDefinitionsDocumentExtension.java
+++ b/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicDefinitionsDocumentExtension.java
@@ -84,21 +84,16 @@ public final class DynamicDefinitionsDocumentExtension extends DefinitionsDocume
     @Override
     public void init(Swagger2MarkupConverter.Context globalContext) {
         Swagger2MarkupProperties extensionsProperties = globalContext.getConfig().getExtensionsProperties();
-        Optional<List<Path>> contentPathProperty = extensionsProperties.getPathList(extensionId + "." + PROPERTY_CONTENT_PATH);
-        if (contentPathProperty.isPresent()) {
-            contentPath = contentPathProperty.get();
-        }
-        else {
-            if (contentPath == null) {
-                if (globalContext.getSwaggerLocation() == null || !globalContext.getSwaggerLocation().getScheme().equals("file")) {
-                    if (logger.isWarnEnabled())
-                        logger.warn("Disable DynamicDefinitionsContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
-                } else {
-                    contentPath = new ArrayList<Path>();
-                    contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
-                }
+        contentPath = extensionsProperties.getPathList(extensionId + "." + PROPERTY_CONTENT_PATH);
+        if (contentPath.isEmpty()) {
+            if (globalContext.getSwaggerLocation() == null || !globalContext.getSwaggerLocation().getScheme().equals("file")) {
+                if (logger.isWarnEnabled())
+                    logger.warn("Disable DynamicDefinitionsContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
+            } else {
+                contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
             }
         }
+
         Optional<MarkupLanguage> extensionMarkupLanguageProperty = extensionsProperties.getMarkupLanguage(extensionId + "." + PROPERTY_MARKUP_LANGUAGE);
         if (extensionMarkupLanguageProperty.isPresent()) {
             extensionMarkupLanguage = extensionMarkupLanguageProperty.get();

--- a/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicDefinitionsDocumentExtension.java
+++ b/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicDefinitionsDocumentExtension.java
@@ -94,8 +94,8 @@ public final class DynamicDefinitionsDocumentExtension extends DefinitionsDocume
                     if (logger.isWarnEnabled())
                         logger.warn("Disable DynamicDefinitionsContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
                 } else {
-                	contentPath = new ArrayList<Path>();
-                	contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
+                    contentPath = new ArrayList<Path>();
+                    contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
                 }
             }
         }
@@ -113,21 +113,21 @@ public final class DynamicDefinitionsDocumentExtension extends DefinitionsDocume
             DynamicContentExtension dynamicContent = new DynamicContentExtension(globalContext, context);
             DynamicDefinitionsDocumentExtension.Position position = context.getPosition();
             switch (position) {
-                case DOCUMENT_BEFORE:
-                case DOCUMENT_AFTER:
-                case DOCUMENT_BEGIN:
-                case DOCUMENT_END:
-                    dynamicContent.extensionsSection(extensionMarkupLanguage, contentPath, contentPrefix(position), levelOffset(context));
-                    break;
-                case DEFINITION_BEFORE:
-                case DEFINITION_BEGIN:
-                case DEFINITION_END:
-                case DEFINITION_AFTER:
-                	List<Path> resolvedPaths = contentPath.stream().map(
-                			p -> p.resolve(Paths.get(IOUtils.normalizeName(context.getDefinitionName().get()))))
-                			.collect(Collectors.toList());
-                    dynamicContent.extensionsSection(extensionMarkupLanguage, resolvedPaths, contentPrefix(position), levelOffset(context));
-                    break;
+            case DOCUMENT_BEFORE:
+            case DOCUMENT_AFTER:
+            case DOCUMENT_BEGIN:
+            case DOCUMENT_END:
+                dynamicContent.extensionsSection(extensionMarkupLanguage, contentPath, contentPrefix(position), levelOffset(context));
+                break;
+            case DEFINITION_BEFORE:
+            case DEFINITION_BEGIN:
+            case DEFINITION_END:
+            case DEFINITION_AFTER:
+                List<Path> resolvedPaths = contentPath.stream().map(
+                        p -> p.resolve(Paths.get(IOUtils.normalizeName(context.getDefinitionName().get()))))
+                        .collect(Collectors.toList());
+                dynamicContent.extensionsSection(extensionMarkupLanguage, resolvedPaths, contentPrefix(position), levelOffset(context));
+                break;
             }
         }
     }

--- a/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicDefinitionsDocumentExtension.java
+++ b/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicDefinitionsDocumentExtension.java
@@ -21,6 +21,7 @@ import io.github.swagger2markup.Swagger2MarkupProperties;
 import io.github.swagger2markup.markup.builder.MarkupLanguage;
 import io.github.swagger2markup.spi.DefinitionsDocumentExtension;
 import io.github.swagger2markup.utils.IOUtils;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
@@ -28,7 +29,10 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Dynamically search for markup files in {@code contentPath} to append in Definitions document.
@@ -39,7 +43,7 @@ public final class DynamicDefinitionsDocumentExtension extends DefinitionsDocume
 
     private static final Logger logger = LoggerFactory.getLogger(DynamicDefinitionsDocumentExtension.class);
 
-    protected Path contentPath;
+    protected List<Path> contentPath;
 
     private static final String PROPERTY_CONTENT_PATH = "contentPath";
     private static final String DEFAULT_EXTENSION_ID = "dynamicDefinitions";
@@ -52,7 +56,7 @@ public final class DynamicDefinitionsDocumentExtension extends DefinitionsDocume
      * @param contentPath the base Path where the content is stored
      * @param extensionMarkupLanguage the MarkupLanguage of the extension content
      */
-    public DynamicDefinitionsDocumentExtension(Path contentPath, MarkupLanguage extensionMarkupLanguage) {
+    public DynamicDefinitionsDocumentExtension(List<Path> contentPath, MarkupLanguage extensionMarkupLanguage) {
         this(null, contentPath, extensionMarkupLanguage);
     }
 
@@ -62,7 +66,7 @@ public final class DynamicDefinitionsDocumentExtension extends DefinitionsDocume
      * @param contentPath the base Path where the content is stored
      * @param extensionMarkupLanguage the MarkupLanguage of the extension content
      */
-    public DynamicDefinitionsDocumentExtension(String extensionId, Path contentPath, MarkupLanguage extensionMarkupLanguage) {
+    public DynamicDefinitionsDocumentExtension(String extensionId, List<Path> contentPath, MarkupLanguage extensionMarkupLanguage) {
         super();
         Validate.notNull(extensionMarkupLanguage);
         Validate.notNull(contentPath);
@@ -80,7 +84,7 @@ public final class DynamicDefinitionsDocumentExtension extends DefinitionsDocume
     @Override
     public void init(Swagger2MarkupConverter.Context globalContext) {
         Swagger2MarkupProperties extensionsProperties = globalContext.getConfig().getExtensionsProperties();
-        Optional<Path> contentPathProperty = extensionsProperties.getPath(extensionId + "." + PROPERTY_CONTENT_PATH);
+        Optional<List<Path>> contentPathProperty = extensionsProperties.getPathList(extensionId + "." + PROPERTY_CONTENT_PATH);
         if (contentPathProperty.isPresent()) {
             contentPath = contentPathProperty.get();
         }
@@ -90,7 +94,8 @@ public final class DynamicDefinitionsDocumentExtension extends DefinitionsDocume
                     if (logger.isWarnEnabled())
                         logger.warn("Disable DynamicDefinitionsContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
                 } else {
-                    contentPath = Paths.get(globalContext.getSwaggerLocation()).getParent();
+                	contentPath = new ArrayList<Path>();
+                	contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
                 }
             }
         }
@@ -118,7 +123,10 @@ public final class DynamicDefinitionsDocumentExtension extends DefinitionsDocume
                 case DEFINITION_BEGIN:
                 case DEFINITION_END:
                 case DEFINITION_AFTER:
-                    dynamicContent.extensionsSection(extensionMarkupLanguage, contentPath.resolve(Paths.get(IOUtils.normalizeName(context.getDefinitionName().get()))), contentPrefix(position), levelOffset(context));
+                	List<Path> resolvedPaths = contentPath.stream().map(
+                			p -> p.resolve(Paths.get(IOUtils.normalizeName(context.getDefinitionName().get()))))
+                			.collect(Collectors.toList());
+                    dynamicContent.extensionsSection(extensionMarkupLanguage, resolvedPaths, contentPrefix(position), levelOffset(context));
                     break;
             }
         }

--- a/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicOverviewDocumentExtension.java
+++ b/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicOverviewDocumentExtension.java
@@ -92,8 +92,8 @@ public final class DynamicOverviewDocumentExtension extends OverviewDocumentExte
                     if (logger.isWarnEnabled())
                         logger.warn("Disable > DynamicOverviewContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
                 } else {
-                	contentPath = new ArrayList<Path>();
-                	contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
+                    contentPath = new ArrayList<Path>();
+                    contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
                 }
             }
         }
@@ -111,12 +111,12 @@ public final class DynamicOverviewDocumentExtension extends OverviewDocumentExte
             DynamicContentExtension dynamicContent = new DynamicContentExtension(globalContext, context);
             OverviewDocumentExtension.Position position = context.getPosition();
             switch (position) {
-                case DOCUMENT_BEFORE:
-                case DOCUMENT_AFTER:    
-                case DOCUMENT_BEGIN:
-                case DOCUMENT_END:
-                    dynamicContent.extensionsSection(extensionMarkupLanguage, contentPath, contentPrefix(position), levelOffset(context));
-                    break;
+            case DOCUMENT_BEFORE:
+            case DOCUMENT_AFTER:    
+            case DOCUMENT_BEGIN:
+            case DOCUMENT_END:
+                dynamicContent.extensionsSection(extensionMarkupLanguage, contentPath, contentPrefix(position), levelOffset(context));
+                break;
             }
         }
     }

--- a/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicOverviewDocumentExtension.java
+++ b/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicOverviewDocumentExtension.java
@@ -82,21 +82,17 @@ public final class DynamicOverviewDocumentExtension extends OverviewDocumentExte
     @Override
     public void init(Swagger2MarkupConverter.Context globalContext) {
         Swagger2MarkupProperties extensionsProperties = globalContext.getConfig().getExtensionsProperties();
-        Optional<List<Path>> contentPathProperty = extensionsProperties.getPathList(extensionId + "." + PROPERTY_CONTENT_PATH);
-        if (contentPathProperty.isPresent()) {
-            contentPath = contentPathProperty.get();
-        }
-        else {
-            if (contentPath == null) {
-                if (globalContext.getSwaggerLocation() == null || !globalContext.getSwaggerLocation().getScheme().equals("file")) {
-                    if (logger.isWarnEnabled())
-                        logger.warn("Disable > DynamicOverviewContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
-                } else {
-                    contentPath = new ArrayList<Path>();
-                    contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
-                }
+        contentPath = extensionsProperties.getPathList(extensionId + "." + PROPERTY_CONTENT_PATH);
+
+        if (contentPath.isEmpty()) {
+            if (globalContext.getSwaggerLocation() == null || !globalContext.getSwaggerLocation().getScheme().equals("file")) {
+                if (logger.isWarnEnabled())
+                    logger.warn("Disable > DynamicOverviewContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
+            } else {
+                contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
             }
         }
+        
         Optional<MarkupLanguage> extensionMarkupLanguageProperty = extensionsProperties.getMarkupLanguage(extensionId + "." + PROPERTY_MARKUP_LANGUAGE);
         if (extensionMarkupLanguageProperty.isPresent()) {
             extensionMarkupLanguage = extensionMarkupLanguageProperty.get();

--- a/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicOverviewDocumentExtension.java
+++ b/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicOverviewDocumentExtension.java
@@ -20,6 +20,7 @@ import io.github.swagger2markup.Swagger2MarkupConverter;
 import io.github.swagger2markup.Swagger2MarkupProperties;
 import io.github.swagger2markup.markup.builder.MarkupLanguage;
 import io.github.swagger2markup.spi.OverviewDocumentExtension;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
@@ -27,6 +28,8 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -38,7 +41,7 @@ public final class DynamicOverviewDocumentExtension extends OverviewDocumentExte
 
     private static final Logger logger = LoggerFactory.getLogger(DynamicOverviewDocumentExtension.class);
 
-    protected Path contentPath;
+    protected List<Path> contentPath;
 
     private static final String DEFAULT_EXTENSION_ID = "dynamicOverview";
     private static final String PROPERTY_CONTENT_PATH = "contentPath";
@@ -51,7 +54,7 @@ public final class DynamicOverviewDocumentExtension extends OverviewDocumentExte
      * @param contentPath the base Path where the content is stored
      * @param extensionMarkupLanguage the MarkupLanguage of the extension content
      */
-    public DynamicOverviewDocumentExtension(Path contentPath, MarkupLanguage extensionMarkupLanguage) {
+    public DynamicOverviewDocumentExtension(List<Path> contentPath, MarkupLanguage extensionMarkupLanguage) {
         this(null, contentPath, extensionMarkupLanguage);
     }
 
@@ -61,7 +64,7 @@ public final class DynamicOverviewDocumentExtension extends OverviewDocumentExte
      * @param contentPath the base Path where the content is stored
      * @param extensionMarkupLanguage the MarkupLanguage of the extension content
      */
-    public DynamicOverviewDocumentExtension(String extensionId, Path contentPath, MarkupLanguage extensionMarkupLanguage) {
+    public DynamicOverviewDocumentExtension(String extensionId, List<Path> contentPath, MarkupLanguage extensionMarkupLanguage) {
         super();
         Validate.notNull(extensionMarkupLanguage);
         Validate.notNull(contentPath);
@@ -79,7 +82,7 @@ public final class DynamicOverviewDocumentExtension extends OverviewDocumentExte
     @Override
     public void init(Swagger2MarkupConverter.Context globalContext) {
         Swagger2MarkupProperties extensionsProperties = globalContext.getConfig().getExtensionsProperties();
-        Optional<Path> contentPathProperty = extensionsProperties.getPath(extensionId + "." + PROPERTY_CONTENT_PATH);
+        Optional<List<Path>> contentPathProperty = extensionsProperties.getPathList(extensionId + "." + PROPERTY_CONTENT_PATH);
         if (contentPathProperty.isPresent()) {
             contentPath = contentPathProperty.get();
         }
@@ -89,7 +92,8 @@ public final class DynamicOverviewDocumentExtension extends OverviewDocumentExte
                     if (logger.isWarnEnabled())
                         logger.warn("Disable > DynamicOverviewContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
                 } else {
-                    contentPath = Paths.get(globalContext.getSwaggerLocation()).getParent();
+                	contentPath = new ArrayList<Path>();
+                	contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
                 }
             }
         }

--- a/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicPathsDocumentExtension.java
+++ b/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicPathsDocumentExtension.java
@@ -84,21 +84,17 @@ public final class DynamicPathsDocumentExtension extends PathsDocumentExtension 
     @Override
     public void init(Swagger2MarkupConverter.Context globalContext) {
         Swagger2MarkupProperties extensionsProperties = globalContext.getConfig().getExtensionsProperties();
-        Optional<List<Path>> contentPathProperty = extensionsProperties.getPathList(extensionId + "." + PROPERTY_CONTENT_PATH);
-        if (contentPathProperty.isPresent()) {
-            contentPath = contentPathProperty.get();
-        }
-        else {
-            if (contentPath == null) {
-                if (globalContext.getSwaggerLocation() == null || !globalContext.getSwaggerLocation().getScheme().equals("file")) {
-                    if (logger.isWarnEnabled())
-                        logger.warn("Disable DynamicOperationsContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
-                } else {
-                    contentPath = new ArrayList<Path>();
-                    contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
-                }
+        contentPath = extensionsProperties.getPathList(extensionId + "." + PROPERTY_CONTENT_PATH);
+        
+        if (contentPath.isEmpty()) {
+            if (globalContext.getSwaggerLocation() == null || !globalContext.getSwaggerLocation().getScheme().equals("file")) {
+                if (logger.isWarnEnabled())
+                    logger.warn("Disable DynamicOperationsContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
+            } else {
+                contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
             }
         }
+
         Optional<MarkupLanguage> extensionMarkupLanguageProperty = extensionsProperties.getMarkupLanguage(extensionId + "." + PROPERTY_MARKUP_LANGUAGE);
         if (extensionMarkupLanguageProperty.isPresent()) {
             extensionMarkupLanguage = extensionMarkupLanguageProperty.get();

--- a/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicPathsDocumentExtension.java
+++ b/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicPathsDocumentExtension.java
@@ -21,6 +21,7 @@ import io.github.swagger2markup.Swagger2MarkupProperties;
 import io.github.swagger2markup.markup.builder.MarkupLanguage;
 import io.github.swagger2markup.spi.PathsDocumentExtension;
 import io.github.swagger2markup.utils.IOUtils;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
@@ -28,7 +29,10 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Dynamically search for markup files in {@code contentPath} to append to Paths document.
@@ -39,7 +43,7 @@ public final class DynamicPathsDocumentExtension extends PathsDocumentExtension 
 
     private static final Logger logger = LoggerFactory.getLogger(DynamicPathsDocumentExtension.class);
 
-    protected Path contentPath;
+    protected List<Path> contentPath;
 
     private static final String DEFAULT_EXTENSION_ID = "dynamicPaths";
     private static final String PROPERTY_CONTENT_PATH = "contentPath";
@@ -52,7 +56,7 @@ public final class DynamicPathsDocumentExtension extends PathsDocumentExtension 
      * @param contentPath the base Path where the content is stored
      * @param extensionMarkupLanguage the MarkupLanguage of the extension content
      */
-    public DynamicPathsDocumentExtension(Path contentPath, MarkupLanguage extensionMarkupLanguage) {
+    public DynamicPathsDocumentExtension(List<Path> contentPath, MarkupLanguage extensionMarkupLanguage) {
         this(null, contentPath, extensionMarkupLanguage);
     }
 
@@ -62,7 +66,7 @@ public final class DynamicPathsDocumentExtension extends PathsDocumentExtension 
      * @param contentPath the base Path where the content is stored
      * @param extensionMarkupLanguage the MarkupLanguage of the extension content
      */
-    public DynamicPathsDocumentExtension(String extensionId, Path contentPath, MarkupLanguage extensionMarkupLanguage) {
+    public DynamicPathsDocumentExtension(String extensionId, List<Path> contentPath, MarkupLanguage extensionMarkupLanguage) {
         super();
         Validate.notNull(extensionMarkupLanguage);
         Validate.notNull(contentPath);
@@ -80,7 +84,7 @@ public final class DynamicPathsDocumentExtension extends PathsDocumentExtension 
     @Override
     public void init(Swagger2MarkupConverter.Context globalContext) {
         Swagger2MarkupProperties extensionsProperties = globalContext.getConfig().getExtensionsProperties();
-        Optional<Path> contentPathProperty = extensionsProperties.getPath(extensionId + "." + PROPERTY_CONTENT_PATH);
+        Optional<List<Path>> contentPathProperty = extensionsProperties.getPathList(extensionId + "." + PROPERTY_CONTENT_PATH);
         if (contentPathProperty.isPresent()) {
             contentPath = contentPathProperty.get();
         }
@@ -90,7 +94,8 @@ public final class DynamicPathsDocumentExtension extends PathsDocumentExtension 
                     if (logger.isWarnEnabled())
                         logger.warn("Disable DynamicOperationsContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
                 } else {
-                    contentPath = Paths.get(globalContext.getSwaggerLocation()).getParent();
+                	contentPath = new ArrayList<Path>();
+                	contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
                 }
             }
         }
@@ -134,7 +139,10 @@ public final class DynamicPathsDocumentExtension extends PathsDocumentExtension 
                 case OPERATION_RESPONSES_END:
                 case OPERATION_SECURITY_BEGIN:
                 case OPERATION_SECURITY_END:
-                    dynamicContent.extensionsSection(extensionMarkupLanguage, contentPath.resolve(IOUtils.normalizeName(context.getOperation().get().getId())), contentPrefix(position), levelOffset(context));
+                	List<Path> resolvedPaths = contentPath.stream().map(
+                			p -> p.resolve(IOUtils.normalizeName(context.getOperation().get().getId())))
+                			.collect(Collectors.toList());
+                    dynamicContent.extensionsSection(extensionMarkupLanguage, resolvedPaths, contentPrefix(position), levelOffset(context));
                     break;
             }
         }

--- a/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicPathsDocumentExtension.java
+++ b/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicPathsDocumentExtension.java
@@ -94,8 +94,8 @@ public final class DynamicPathsDocumentExtension extends PathsDocumentExtension 
                     if (logger.isWarnEnabled())
                         logger.warn("Disable DynamicOperationsContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
                 } else {
-                	contentPath = new ArrayList<Path>();
-                	contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
+                    contentPath = new ArrayList<Path>();
+                    contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
                 }
             }
         }
@@ -113,37 +113,37 @@ public final class DynamicPathsDocumentExtension extends PathsDocumentExtension 
             DynamicContentExtension dynamicContent = new DynamicContentExtension(globalContext, context);
             PathsDocumentExtension.Position position = context.getPosition();
             switch (position) {
-                case DOCUMENT_BEFORE:
-                case DOCUMENT_AFTER:
-                case DOCUMENT_BEGIN:
-                case DOCUMENT_END:
-                    dynamicContent.extensionsSection(extensionMarkupLanguage, contentPath, contentPrefix(position), levelOffset(context));
-                    break;
-                case OPERATION_BEFORE:
-                case OPERATION_BEGIN:
-                case OPERATION_END:
-                case OPERATION_AFTER:
-                case OPERATION_DESCRIPTION_BEFORE:
-                case OPERATION_DESCRIPTION_AFTER:
-                case OPERATION_PARAMETERS_BEFORE:
-                case OPERATION_PARAMETERS_AFTER:
-                case OPERATION_RESPONSES_BEFORE:
-                case OPERATION_RESPONSES_AFTER:
-                case OPERATION_SECURITY_BEFORE:
-                case OPERATION_SECURITY_AFTER:
-                case OPERATION_DESCRIPTION_BEGIN:
-                case OPERATION_DESCRIPTION_END:
-                case OPERATION_PARAMETERS_BEGIN:
-                case OPERATION_PARAMETERS_END:
-                case OPERATION_RESPONSES_BEGIN:
-                case OPERATION_RESPONSES_END:
-                case OPERATION_SECURITY_BEGIN:
-                case OPERATION_SECURITY_END:
-                	List<Path> resolvedPaths = contentPath.stream().map(
-                			p -> p.resolve(IOUtils.normalizeName(context.getOperation().get().getId())))
-                			.collect(Collectors.toList());
-                    dynamicContent.extensionsSection(extensionMarkupLanguage, resolvedPaths, contentPrefix(position), levelOffset(context));
-                    break;
+            case DOCUMENT_BEFORE:
+            case DOCUMENT_AFTER:
+            case DOCUMENT_BEGIN:
+            case DOCUMENT_END:
+                dynamicContent.extensionsSection(extensionMarkupLanguage, contentPath, contentPrefix(position), levelOffset(context));
+                break;
+            case OPERATION_BEFORE:
+            case OPERATION_BEGIN:
+            case OPERATION_END:
+            case OPERATION_AFTER:
+            case OPERATION_DESCRIPTION_BEFORE:
+            case OPERATION_DESCRIPTION_AFTER:
+            case OPERATION_PARAMETERS_BEFORE:
+            case OPERATION_PARAMETERS_AFTER:
+            case OPERATION_RESPONSES_BEFORE:
+            case OPERATION_RESPONSES_AFTER:
+            case OPERATION_SECURITY_BEFORE:
+            case OPERATION_SECURITY_AFTER:
+            case OPERATION_DESCRIPTION_BEGIN:
+            case OPERATION_DESCRIPTION_END:
+            case OPERATION_PARAMETERS_BEGIN:
+            case OPERATION_PARAMETERS_END:
+            case OPERATION_RESPONSES_BEGIN:
+            case OPERATION_RESPONSES_END:
+            case OPERATION_SECURITY_BEGIN:
+            case OPERATION_SECURITY_END:
+                List<Path> resolvedPaths = contentPath.stream().map(
+                        p -> p.resolve(IOUtils.normalizeName(context.getOperation().get().getId())))
+                        .collect(Collectors.toList());
+                dynamicContent.extensionsSection(extensionMarkupLanguage, resolvedPaths, contentPrefix(position), levelOffset(context));
+                break;
             }
         }
     }

--- a/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicSecurityDocumentExtension.java
+++ b/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicSecurityDocumentExtension.java
@@ -94,8 +94,8 @@ public final class DynamicSecurityDocumentExtension extends SecurityDocumentExte
                     if (logger.isWarnEnabled())
                         logger.warn("Disable > DynamicSecurityContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
                 } else {
-                	contentPath = new ArrayList<Path>();
-                	contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
+                    contentPath = new ArrayList<Path>();
+                    contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
                 }
             }
         }
@@ -113,21 +113,21 @@ public final class DynamicSecurityDocumentExtension extends SecurityDocumentExte
             DynamicContentExtension dynamicContent = new DynamicContentExtension(globalContext, context);
             SecurityDocumentExtension.Position position = context.getPosition();
             switch (position) {
-                case DOCUMENT_BEFORE:
-                case DOCUMENT_AFTER:
-                case DOCUMENT_BEGIN:
-                case DOCUMENT_END:
-                    dynamicContent.extensionsSection(extensionMarkupLanguage, contentPath, contentPrefix(position), levelOffset(context));
-                    break;
-                case SECURITY_SCHEME_BEFORE:
-                case SECURITY_SCHEME_BEGIN:
-                case SECURITY_SCHEME_END:
-                case SECURITY_SCHEME_AFTER:
-                	List<Path> resolvedPaths = contentPath.stream().map(
-                			p -> p.resolve(IOUtils.normalizeName(context.getSecuritySchemeName().get())))
-                			.collect(Collectors.toList());
-                    dynamicContent.extensionsSection(extensionMarkupLanguage, resolvedPaths, contentPrefix(position), levelOffset(context));
-                    break;
+            case DOCUMENT_BEFORE:
+            case DOCUMENT_AFTER:
+            case DOCUMENT_BEGIN:
+            case DOCUMENT_END:
+                dynamicContent.extensionsSection(extensionMarkupLanguage, contentPath, contentPrefix(position), levelOffset(context));
+                break;
+            case SECURITY_SCHEME_BEFORE:
+            case SECURITY_SCHEME_BEGIN:
+            case SECURITY_SCHEME_END:
+            case SECURITY_SCHEME_AFTER:
+                List<Path> resolvedPaths = contentPath.stream().map(
+                        p -> p.resolve(IOUtils.normalizeName(context.getSecuritySchemeName().get())))
+                        .collect(Collectors.toList());
+                dynamicContent.extensionsSection(extensionMarkupLanguage, resolvedPaths, contentPrefix(position), levelOffset(context));
+                break;
             }
         }
     }

--- a/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicSecurityDocumentExtension.java
+++ b/swagger2markup-import-files-ext/src/main/java/io/github/swagger2markup/extensions/DynamicSecurityDocumentExtension.java
@@ -84,21 +84,18 @@ public final class DynamicSecurityDocumentExtension extends SecurityDocumentExte
     @Override
     public void init(Swagger2MarkupConverter.Context globalContext) {
         Swagger2MarkupProperties extensionsProperties = globalContext.getConfig().getExtensionsProperties();
-        Optional<List<Path>> contentPathProperty = extensionsProperties.getPathList(extensionId + "." + PROPERTY_CONTENT_PATH);
-        if (contentPathProperty.isPresent()) {
-            contentPath = contentPathProperty.get();
-        }
-        else {
-            if (contentPath == null) {
-                if (globalContext.getSwaggerLocation() == null || !globalContext.getSwaggerLocation().getScheme().equals("file")) {
-                    if (logger.isWarnEnabled())
-                        logger.warn("Disable > DynamicSecurityContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
-                } else {
-                    contentPath = new ArrayList<Path>();
-                    contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
-                }
+        contentPath = extensionsProperties.getPathList(extensionId + "." + PROPERTY_CONTENT_PATH);
+       
+        if (contentPath.isEmpty()) {
+            if (globalContext.getSwaggerLocation() == null || !globalContext.getSwaggerLocation().getScheme().equals("file")) {
+                if (logger.isWarnEnabled())
+                    logger.warn("Disable > DynamicSecurityContentExtension > Can't set default contentPath from swaggerLocation. You have to explicitly configure the content path.");
+            } else {
+                contentPath = new ArrayList<Path>();
+                contentPath.add(Paths.get(globalContext.getSwaggerLocation()).getParent());
             }
         }
+
         Optional<MarkupLanguage> extensionMarkupLanguageProperty = extensionsProperties.getMarkupLanguage(extensionId + "." + PROPERTY_MARKUP_LANGUAGE);
         if (extensionMarkupLanguageProperty.isPresent()) {
             extensionMarkupLanguage = extensionMarkupLanguageProperty.get();

--- a/swagger2markup-import-files-ext/src/test/java/io/github/swagger2markup/extensions/DynamicDocumentExtensionTest.java
+++ b/swagger2markup-import-files-ext/src/test/java/io/github/swagger2markup/extensions/DynamicDocumentExtensionTest.java
@@ -96,4 +96,65 @@ public class DynamicDocumentExtensionTest {
                 "Pet extension");
 
     }
+    
+    @Test
+    public void testSwagger2AsciiDocExtensionsMultiContentFolders() throws IOException, URISyntaxException {
+        //Given
+        Path file = Paths.get(DynamicDocumentExtensionTest.class.getResource("/yaml/swagger_petstore.yaml").toURI());
+        Path outputDirectory = Paths.get("build/test/asciidoc/generated");
+        FileUtils.deleteQuietly(outputDirectory.toFile());
+
+        //When
+        Properties properties = new Properties();
+        properties.load(DynamicDocumentExtensionTest.class.getResourceAsStream("/config/asciidoc/config2.properties"));
+        Swagger2MarkupConfig config = new Swagger2MarkupConfigBuilder(properties)
+                .build();
+        Swagger2MarkupExtensionRegistry registry = new Swagger2MarkupExtensionRegistryBuilder()
+                //.withDefinitionsDocumentExtension(new DynamicDefinitionsDocumentExtension(Paths.get("src/test/resources/docs/asciidoc/extensions")))
+                //.withPathsDocumentExtension(new DynamicPathsDocumentExtension(Paths.get("src/test/resources/docs/asciidoc/extensions")))
+                .build();
+        Swagger2MarkupConverter.from(file)
+                .withConfig(config)
+                .withExtensionRegistry(registry)
+                .build()
+                .toFolder(outputDirectory);
+
+        //Then
+        assertThat(new String(Files.readAllBytes(outputDirectory.resolve("paths.adoc")))).contains(
+                "Pet update request extension").contains("Pet update request extension 2");
+        assertThat(new String(Files.readAllBytes(outputDirectory.resolve("definitions.adoc")))).contains(
+                "Pet extension").contains("Pet extension 2");
+
+    }
+    
+    @Test
+    public void testSwagger2MarkdownExtensionsMultiContentFolders() throws IOException, URISyntaxException {
+        //Given
+        Path file = Paths.get(DynamicDocumentExtensionTest.class.getResource("/yaml/swagger_petstore.yaml").toURI());
+        Path outputDirectory = Paths.get("build/test/markdown/generated");
+        FileUtils.deleteQuietly(outputDirectory.toFile());
+
+        //When
+        Properties properties = new Properties();
+        properties.load(DynamicDocumentExtensionTest.class.getResourceAsStream("/config/markdown/config2.properties"));
+        Swagger2MarkupConfig config = new Swagger2MarkupConfigBuilder(properties)
+                .withMarkupLanguage(MarkupLanguage.MARKDOWN)
+                .build();
+        Swagger2MarkupExtensionRegistry registry = new Swagger2MarkupExtensionRegistryBuilder()
+                //.withDefinitionsDocumentExtension(new DynamicDefinitionsDocumentExtension(Paths.get("src/test/resources/docs/markdown/extensions")))
+                //.withPathsDocumentExtension(new DynamicPathsDocumentExtension(Paths.get("src/test/resources/docs/markdown/extensions")))
+                .build();
+        Swagger2MarkupConverter.from(file)
+                .withConfig(config)
+                .withExtensionRegistry(registry)
+                .build()
+                .toFolder(outputDirectory);
+
+        //Then
+        assertThat(new String(Files.readAllBytes(outputDirectory.resolve("paths.md")))).contains(
+                "Pet update request extension").contains("Pet update request extension 2");
+        assertThat(new String(Files.readAllBytes(outputDirectory.resolve("definitions.md")))).contains(
+                "Pet extension").contains("Pet extension 2");
+
+    }
 }

--- a/swagger2markup-import-files-ext/src/test/resources/config/asciidoc/config2.properties
+++ b/swagger2markup-import-files-ext/src/test/resources/config/asciidoc/config2.properties
@@ -1,0 +1,5 @@
+swagger2markup.listDelimiterEnabled=true
+swagger2markup.extensions.dynamicDefinitions.contentPath=src/test/resources/docs/asciidoc/extensions,src/test/resources/docs/asciidoc/other/extensions
+swagger2markup.extensions.dynamicOverview.contentPath=src/test/resources/docs/asciidoc/extensions,src/test/resources/docs/asciidoc/other/extensions
+swagger2markup.extensions.dynamicPaths.contentPath=src/test/resources/docs/asciidoc/extensions,src/test/resources/docs/asciidoc/other/extensions
+swagger2markup.extensions.dynamicSecurity.contentPath=src/test/resources/docs/asciidoc/extensions,src/test/resources/docs/asciidoc/other/extensions

--- a/swagger2markup-import-files-ext/src/test/resources/config/markdown/config2.properties
+++ b/swagger2markup-import-files-ext/src/test/resources/config/markdown/config2.properties
@@ -1,0 +1,5 @@
+swagger2markup.listDelimiterEnabled=true
+swagger2markup.extensions.dynamicDefinitions.contentPath=src/test/resources/docs/markdown/extensions,src/test/resources/docs/markdown/other/extensions
+swagger2markup.extensions.dynamicOverview.contentPath=src/test/resources/docs/markdown/extensions,src/test/resources/docs/markdown/other/extensions
+swagger2markup.extensions.dynamicPaths.contentPath=src/test/resources/docs/markdown/extensions,src/test/resources/docs/markdown/other/extensions
+swagger2markup.extensions.dynamicSecurity.contentPath=src/test/resources/docs/markdown/extensions,src/test/resources/docs/markdown/other/extensions

--- a/swagger2markup-import-files-ext/src/test/resources/docs/asciidoc/other/extensions/Pet/definition-end-example2.adoc
+++ b/swagger2markup-import-files-ext/src/test/resources/docs/asciidoc/other/extensions/Pet/definition-end-example2.adoc
@@ -1,0 +1,3 @@
+== Pet extension 2
+
+This is an extension for this definition

--- a/swagger2markup-import-files-ext/src/test/resources/docs/asciidoc/other/extensions/updatePet/operation-end-example2.adoc
+++ b/swagger2markup-import-files-ext/src/test/resources/docs/asciidoc/other/extensions/updatePet/operation-end-example2.adoc
@@ -1,0 +1,11 @@
+== Pet update request extension 2
+
+----
+Request
+----
+
+== Pet update response extension 2
+
+----
+Response
+----

--- a/swagger2markup-import-files-ext/src/test/resources/docs/markdown/other/extensions/Pet/definition-end-example2.md
+++ b/swagger2markup-import-files-ext/src/test/resources/docs/markdown/other/extensions/Pet/definition-end-example2.md
@@ -1,0 +1,3 @@
+## Pet extension 2
+
+This is another extension for this definition

--- a/swagger2markup-import-files-ext/src/test/resources/docs/markdown/other/extensions/updatePet/operation-end-example2.md
+++ b/swagger2markup-import-files-ext/src/test/resources/docs/markdown/other/extensions/updatePet/operation-end-example2.md
@@ -1,0 +1,10 @@
+## Pet update request extension 2
+
+```
+Request
+```
+
+## Pet update response extension 2
+
+```
+Response

--- a/swagger2markup-spring-restdocs-ext/src/test/resources/expected_results/asciidoc/spring_rest_docs/paths.adoc
+++ b/swagger2markup-spring-restdocs-ext/src/test/resources/expected_results/asciidoc/spring_rest_docs/paths.adoc
@@ -328,7 +328,7 @@ Returns a pet when ID &lt; 10. ID &gt; 10 or nonintegers will simulate API error
 |===
 |Type|Name|Description|Schema
 |**Path**|**petId** +
-__required__|ID of pet that needs to be fetched|integer(int64)
+__required__|ID of pet that needs to be fetched|integer (int64)
 |===
 
 
@@ -383,7 +383,7 @@ DELETE /pets/{petId}
 |**Header**|**api_key** +
 __required__||string
 |**Path**|**petId** +
-__required__|Pet id to delete|integer(int64)
+__required__|Pet id to delete|integer (int64)
 |===
 
 


### PR DESCRIPTION
Dependent on master branch of swagger2markup. Specifically, the listDelimiter functionality must have the capability to be enabled with the "swagger2markup.listDelimiterEnabled" configuration property.

Alters the dynamic content extension to support multiple content folders for each type specified in the extension properties (swagger2markup.extensions.dynamicDefinitions.contentPath, etc.).

Also "fixes" the spring rest docs extension's unit test to match what the swagger2markup master branch currently generates. Specifically numeric types now have a space "integer (int64)", where previously they did not "integer(int64)". Not sure if it was intended to change in this way, but any fix would need to take place in the swagger2markup project.
